### PR TITLE
Fix apache2 listen attribute

### DIFF
--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -5,8 +5,8 @@
 # Copyright 2015, KLM Royal Dutch Airlines
 #
 
-node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['crowd']['apache2']['port']] unless node['apache']['listen_ports'].include?(node['crowd']['apache2']['port'])
-node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['crowd']['apache2']['ssl']['port']] unless node['apache']['listen_ports'].include?(node['crowd']['apache2']['ssl']['port'])
+node.set['apache']['listen'] = node['apache']['listen'] + ["*:#{node['crowd']['apache2']['port']}"] unless node['apache']['listen'].include?("*:#{node['crowd']['apache2']['port']}")
+node.set['apache']['listen'] = node['apache']['listen'] + ["*:#{node['crowd']['apache2']['ssl']['port']}"] unless node['apache']['listen'].include?("*:#{node['crowd']['apache2']['ssl']['port']}")
 
 include_recipe 'apache2'
 include_recipe 'apache2::mod_proxy'


### PR DESCRIPTION
apache2.listen_ports is no longer declared in latest apache2 cookbook.

This change fix https://github.com/afklm/crowd/issues/7