### PR TITLE
Use same ark format as confluence/jira cookbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## x.y.z (pending)
 
+* Slight tweaks to ark usage to standardize with Jira/Confluence
+  cookbooks.[[GH-13]](https://github.com/afklm/crowd/issues/13)
+
 ## 1.1.3
 
 * Add Crowd 2.8.4 support

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,7 @@ default['java']['jdk_version']                         = '7'
 # Crowd itself
 default['crowd']['home_path']          = '/var/atlassian/application-data/crowd'
 default['crowd']['init_type']          = 'sysv'
-default['crowd']['install_path']       = '/opt/atlassian'
+default['crowd']['install_path']       = '/opt/atlassian/crowd'
 default['crowd']['install_type']       = 'standalone'
 default['crowd']['version']            = '2.9.1'
 default['crowd']['ssl']                = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ recipe 'crowd::apache2',    'Installs/configures Apache 2 as proxy (ports 80/443
 recipe 'crowd::nginx',      'Installs/configures Nginx as proxy (ports 80/443)'
 
 # Only tested on Ubuntu, YMMV on other platforms
-%w( debian ubuntu ).each do |os|
+%w(debian ubuntu).each do |os|
   supports os
 end
 

--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -13,7 +13,7 @@ end
 
 # Only needed for standalone
 if node['crowd']['install_type'] == 'standalone'
-  template "#{node['crowd']['install_path']}/crowd/crowd-webapp/WEB-INF/classes/crowd-init.properties" do
+  template "#{node['crowd']['install_path']}/crowd-webapp/WEB-INF/classes/crowd-init.properties" do
     source 'crowd-init.properties.erb'
     mode '0644'
     owner node['crowd']['user']
@@ -21,7 +21,7 @@ if node['crowd']['install_type'] == 'standalone'
     notifies :restart, 'service[crowd]', :delayed
   end
 
-  template "#{node['crowd']['install_path']}/crowd/apache-tomcat/bin/setenv.sh" do
+  template "#{node['crowd']['install_path']}/apache-tomcat/bin/setenv.sh" do
     source 'setenv.sh.erb'
     mode '0744'
     owner node['crowd']['user']

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -15,23 +15,23 @@ include_recipe 'nokogiri::chefgem'
 ruby_block 'compression' do
   block do
     require 'nokogiri'
-    f = File.read("#{node['crowd']['install_path']}/crowd/apache-tomcat/conf/server.xml")
+    f = File.read("#{node['crowd']['install_path']}/apache-tomcat/conf/server.xml")
     doc = Nokogiri::XML(f)
     doc.xpath('/Server/Service/Connector[@port="8095"]').each do |change|
       next unless change.name == 'Connector'
       change['compression'] = 'on'
       change['compressableMimeType'] = 'text/html,text/xml,text/plain,text/css,application/json,application/javascript,application/x-javascript'
     end
-    File.open("#{node['crowd']['install_path']}/crowd/apache-tomcat/conf/server.xml", 'w') { |f| f.print(doc.to_xml) }
+    File.open("#{node['crowd']['install_path']}/apache-tomcat/conf/server.xml", 'w') { |f| f.print(doc.to_xml) }
   end
-  not_if("cat #{node['crowd']['install_path']}/crowd/apache-tomcat/conf/server.xml | grep compression")
+  not_if("cat #{node['crowd']['install_path']}/apache-tomcat/conf/server.xml | grep compression")
 end
 
 # Edit the server.xml so the proxy + Crowd works properly to allow HTTPS
 ruby_block 'remoteIpValve' do
   block do
     require 'nokogiri'
-    f = File.read("#{node['crowd']['install_path']}/crowd/apache-tomcat/conf/server.xml")
+    f = File.read("#{node['crowd']['install_path']}/apache-tomcat/conf/server.xml")
     doc = Nokogiri::XML(f)
     doc.xpath('/Server/Service/Engine[@name="Catalina"]').each do |change|
       valve = Nokogiri::XML::Node.new 'Valve', doc
@@ -41,9 +41,9 @@ ruby_block 'remoteIpValve' do
       valve['internalProxies'] = '127.0.0.1'
       change.add_child(valve)
     end
-    File.open("#{node['crowd']['install_path']}/crowd/apache-tomcat/conf/server.xml", 'w') { |f| f.print(doc.to_xml) }
+    File.open("#{node['crowd']['install_path']}/apache-tomcat/conf/server.xml", 'w') { |f| f.print(doc.to_xml) }
   end
-  not_if("cat #{node['crowd']['install_path']}/crowd/apache-tomcat/conf/server.xml | grep RemoteIpValve")
+  not_if("cat #{node['crowd']['install_path']}/apache-tomcat/conf/server.xml | grep RemoteIpValve")
 end
 
 nginx_proxy node['crowd']['proxy']['url'] do

--- a/recipes/standalone.rb
+++ b/recipes/standalone.rb
@@ -50,8 +50,8 @@ end
 # TODO: replace by Chef::ProviderResolver.new(node, resource, action)
 ark 'crowd' do
   url crowd_artifact_url
-  prefix_root node['crowd']['install_path']
-  prefix_home node['crowd']['install_path']
+  prefix_root File.dirname(node['crowd']['install_path'])
+  home_dir node['crowd']['install_path']
   checksum crowd_artifact_checksum
   version node['crowd']['version']
   owner node['crowd']['user']

--- a/recipes/standalone.rb
+++ b/recipes/standalone.rb
@@ -10,7 +10,7 @@ settings = Crowd.settings(node)
 directory File.dirname(node['crowd']['home_path']) do
   owner 'root'
   group 'root'
-  mode 00755
+  mode '0755'
   action :create
   recursive true
 end
@@ -42,7 +42,7 @@ end
 directory node['crowd']['install_path'] do
   owner 'root'
   group 'root'
-  mode 00755
+  mode '0755'
   action :create
   recursive true
 end

--- a/templates/default/crowd.init.erb
+++ b/templates/default/crowd.init.erb
@@ -28,7 +28,7 @@
 APP=CROWD
 # Name of the user to run as
 USER=<%= node['crowd']['user'] %>
-BASE=<%= node['crowd']['install_path'] %>/crowd
+BASE=<%= node['crowd']['install_path'] %>
 
 function start {
     echo "Starting $APP"


### PR DESCRIPTION
Provides dir structure like so:

```
/opt/atlassian
├── crowd -> /opt/atlassian/crowd-2.9.1
└── crowd-2.9.1
```

EDIT: This makes it so that the install_path is the actual install path that's referenced in all the atlassian docs (ie. `/opt/atlassian/PRODUCT`, and not the *containing* directory, which is a bit unintuitive