### PR TITLE
Create noop for database install/config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## x.y.z (pending)
 
+- Added ability to set database type to `hsqldb` or `none` for a no-op.
+  [[GH-14]](https://github.com/afklm/crowd/issues/14)
+
 ## 1.1.3
 
 * Add Crowd 2.8.4 support

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ These attributes are under the `node['crowd']['database']` namespace.
 
 Attribute    | Description                                           | Type    | Default
 -------------|-------------------------------------------------------|---------|---------------------------------------
-type         | DB type to use - currently only postgresql            | String  | postgresql
+type         | DB type to use - "postgresql" or "hsqldb"/"none"      | String  | postgresql
 host         | FQDN to DB machine or "localhost" for local installs  | String  | localhost
 port         | DB port                                               | String  | 5432
 name         | DB name                                               | String  | crowd

--- a/recipes/database.rb
+++ b/recipes/database.rb
@@ -34,4 +34,7 @@ when 'postgresql'
     database_name settings['database']['name']
     action [:create, :grant]
   end
+
+when 'hsqldb', 'none'
+  # no-op
 end


### PR DESCRIPTION
Would be great to allow "none" or "hsqldb" to avoid installing and database. I'm working in a very restricted network environment, and installing postgres (with its custom repos) would prevent yum from working. An explicit command to skip database install would be helpful :)

PR forthcoming